### PR TITLE
do not allow to exchange same currency

### DIFF
--- a/src/Domain/DailyLedger.php
+++ b/src/Domain/DailyLedger.php
@@ -36,8 +36,12 @@ final class DailyLedger
 
     public function exchange(MonetaryAmount $source, MonetaryAmount $target): void
     {
+        if ($source->currencyCode === $target->currencyCode) {
+            throw new \InvalidArgumentException('Cannot exchange same currency');
+        }
+
         if ($this->getAmount($target->currencyCode)->lessThan($target)) {
-            throw new \InvalidArgumentException(sprintf('Insufficient funds of %s', $target->currencyCode->value));
+            throw new \InvalidArgumentException(sprintf('Insufficient funds to deliver %s', $target->toCurrencyString()));
         }
 
         $this->recordThat(new CurrencyExchanged($source, $target));

--- a/src/Domain/MonetaryAmount.php
+++ b/src/Domain/MonetaryAmount.php
@@ -45,6 +45,11 @@ final readonly class MonetaryAmount
         return $this->amount->toString();
     }
 
+    public function toCurrencyString(): string
+    {
+        return sprintf('%s %s', $this->toDecimalString(), $this->currencyCode->value);
+    }
+
     private function assertCurrency(self $other, string $message): void
     {
         if ($this->currencyCode !== $other->currencyCode) {

--- a/tests/Unit/Domain/DailyLedgerTest.php
+++ b/tests/Unit/Domain/DailyLedgerTest.php
@@ -48,10 +48,20 @@ final class DailyLedgerTest extends TestCase
     public function it_will_not_allow_to_exchange_money_if_there_is_no_sufficient_funds_from_the_beginning(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Insufficient funds of USD');
+        $this->expectExceptionMessage('Insufficient funds to deliver 4.00 USD');
 
         $ledger = DailyLedger::open([]);
         $ledger->exchange(MonetaryAmount::fromString('1.00', CurrencyCode::PLN), MonetaryAmount::fromString('4.00', CurrencyCode::USD));
+    }
+
+    #[Test]
+    public function it_will_not_allow_to_exchange_the_same_currency(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Cannot exchange same currency');
+
+        $ledger = DailyLedger::open([]);
+        $ledger->exchange(MonetaryAmount::fromString('1.00', CurrencyCode::USD), MonetaryAmount::fromString('4.00', CurrencyCode::USD));
     }
 
     #[Test]

--- a/tests/Unit/Domain/MonetaryAmountTest.php
+++ b/tests/Unit/Domain/MonetaryAmountTest.php
@@ -69,6 +69,10 @@ final class MonetaryAmountTest extends TestCase
             ['20.00', '10.00', false],
             ['10.00', '10.00', false],
             ['10.00', '9.99', false],
+            ['10.001', '10.00', false],
+            ['0.00', '0.00', false],
+            ['-20.00', '-10.00', true],
+            ['-10.00', '-20.00', false],
         ];
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added `toCurrencyString()` method to display monetary amounts with currency code

- **Bug Fixes**
  - Improved error handling for currency exchanges
  - Enhanced error messages for insufficient funds scenarios

- **Tests**
  - Expanded test coverage for monetary amount comparisons
  - Added test for preventing same-currency exchanges

The update introduces more robust error handling and improved display of monetary amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->